### PR TITLE
Remove unused strings

### DIFF
--- a/app/src/main/res/values-cn/strings.xml
+++ b/app/src/main/res/values-cn/strings.xml
@@ -25,15 +25,6 @@
     <string name="swipe_right_app">右滑应用</string>
     <string name="clock_click_app">单击时钟启动的应用</string>
     <string name="date_click_app">单击日期启动的应用</string>
-    <string name="_0" translatable="false">0</string>
-    <string name="_1" translatable="false">1</string>
-    <string name="_2" translatable="false">2</string>
-    <string name="_3" translatable="false">3</string>
-    <string name="_4" translatable="false">4</string>
-    <string name="_5" translatable="false">5</string>
-    <string name="_6" translatable="false">6</string>
-    <string name="_7" translatable="false">7</string>
-    <string name="_8" translatable="false">8</string>
     <string name="commit">Commit</string>
     <string name="app_drawer_tips">提示：下滑不予理会。滚动隐藏键盘。</string>
     <string name="okay">好的</string>
@@ -65,9 +56,6 @@
     <string name="lang_system">系统</string>
 
     <string name="app_text_size">文本尺寸</string>
-    <string name="text_size_huge">巨大</string>
-    <string name="text_size_normal">正常</string>
-    <string name="text_size_small">小</string>
 
     <string name="hidden_apps">隐藏的应用</string>
     

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -49,5 +49,7 @@
     <string name="close">Schließen</string>
     <string name="hidden_apps">Versteckte Apps</string>
     <string name="app_language">Sprache</string>
+
+
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -55,10 +55,8 @@
     <string name="lang_system">Sistema</string>
     
     <string name="app_text_size">Texto en pantalla</string>
-    <string name="text_size_huge">Grande</string>
-    <string name="text_size_normal">Normal</string>
-    <string name="text_size_small">Pequeño</string>
 
     <string name="hidden_apps">Aplicaciones ocultas</string>
+
 
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -23,15 +23,6 @@
     <string name="swipe_right_app">برنامه ای که با کشیدن به راست باز می شود</string>
     <string name="clock_click_app">برنامه ای که با ضربه روی ساعت باز می شود</string>
     <string name="date_click_app">برنامه ای که با ضربه روی تاریخ باز می شود</string>
-    <string name="_0" translatable="false">0</string>
-    <string name="_1" translatable="false">1</string>
-    <string name="_2" translatable="false">2</string>
-    <string name="_3" translatable="false">3</string>
-    <string name="_4" translatable="false">4</string>
-    <string name="_5" translatable="false">5</string>
-    <string name="_6" translatable="false">6</string>
-    <string name="_7" translatable="false">7</string>
-    <string name="_8" translatable="false">8</string>
     <string name="app_drawer_tips">نکته: برای ردکردن، انگشت خود را به پایین بکشید. برای مخفی کردن صفحه کلید، پیمایش کنید</string>
     <string name="okay">باشه</string>
     <string name="double_tap_lock_is_enabled_message">اگر دوبار ضربه برای قفل صفحه، اثر انگشت یا قفل با چهره را غیرفعال می‌کند، تنظیمات Olauncher را باز کنید، روی «آزمایشی» ضربه بزنید و دستورالعمل‌ها را دنبال کنید. متشکرم.</string>
@@ -59,20 +50,10 @@
     <string name="close">بستن</string>
     <string name="app_language">زبان</string>
     <string name="lang_system">سیستم</string>
-    <string name="lang_en" translatable="false">انگلیسی</string>
-    <string name="lang_de" translatable="false">آلمانی</string>
-    <string name="lang_es" translatable="false">اسپانیولی</string>
-    <string name="lang_fr" translatable="false">فرانسوی</string>
-    <string name="lang_it" translatable="false">ایتالیایی</string>
-    <string name="lang_se" translatable="false">سوئدی</string>
-    <string name="lang_tr" translatable="false">ترکی</string>
-    <string name="lang_gr" translatable="false">یونانی</string>
 
     <string name="app_text_size">اندازه متن</string>
-    <string name="text_size_huge">درشت</string>
-    <string name="text_size_normal">عادی</string>
-    <string name="text_size_small">کوچک</string>
 
     <string name="hidden_apps">برنامه های مخفی</string>
+
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -56,9 +56,6 @@
     <string name="lang_system">Identique au Système</string>
     
     <string name="app_text_size">Taille de la police</string>
-    <string name="text_size_huge">Grande</string>
-    <string name="text_size_normal">Normal</string>
-    <string name="text_size_small">Petite</string>
     
     <string name="hidden_apps">Applications masquées</string>
 

--- a/app/src/main/res/values-gr/strings.xml
+++ b/app/src/main/res/values-gr/strings.xml
@@ -50,9 +50,10 @@
     <string name="close">Κλείσιμο</string>
     <string name="app_language">Γλώσσα Εφαρμογής</string>
     <string name="lang_system">Γλώσσα Συστήματος</string>
+
     <string name="app_text_size">Μέγεθος Γραμματοσειράς</string>
-    <string name="text_size_huge">Μεγάλο</string>
-    <string name="text_size_normal">Μεσαίο</string>
-    <string name="text_size_small">Μικρό</string>
+
     <string name="hidden_apps">Κρυφές εφαρμογές</string>
+
+
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -25,15 +25,6 @@
     <string name="swipe_right_app">Geser ke kanan</string>
     <string name="clock_click_app">Aplikasi ketika menekan jam </string>
     <string name="date_click_app">Aplikasi ketika menekan tanggal</string>
-    <string name="_0" translatable="false">0</string>
-    <string name="_1" translatable="false">1</string>
-    <string name="_2" translatable="false">2</string>
-    <string name="_3" translatable="false">3</string>
-    <string name="_4" translatable="false">4</string>
-    <string name="_5" translatable="false">5</string>
-    <string name="_6" translatable="false">6</string>
-    <string name="_7" translatable="false">7</string>
-    <string name="_8" translatable="false">8</string>
     <string name="commit">Lakukan</string>
     <string name="app_drawer_tips">Tip: Geser ke bawah untuk menutup. Scroll untuk menyembunyikan papan ketik.</string>
     <string name="okay">OK</string>
@@ -64,9 +55,6 @@
     <string name="lang_system">Sistem</string>
 
     <string name="app_text_size">Ukuran teks</string>
-    <string name="text_size_huge">Besar</string>
-    <string name="text_size_normal">Sedang</string>
-    <string name="text_size_small">Kecil</string>
 
     <string name="hidden_apps">Aplikasi tersembunyi</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -53,9 +53,6 @@
     <string name="lang_system">Sistema</string>
     
     <string name="app_text_size">Dimensione Testo</string>
-    <string name="text_size_huge">Grande</string>
-    <string name="text_size_normal">Normale</string>
-    <string name="text_size_small">Piccolo</string>
 
     <string name="hidden_apps">App nascoste</string>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -25,15 +25,6 @@
     <string name="swipe_right_app">오른쪽 스와이프 시 실행 앱</string>
     <string name="clock_click_app">시계 클릭 시 실행 앱</string>
     <string name="date_click_app">날짜 클릭 시 실행 앱</string>
-    <string name="_0" translatable="false">0</string>
-    <string name="_1" translatable="false">1</string>
-    <string name="_2" translatable="false">2</string>
-    <string name="_3" translatable="false">3</string>
-    <string name="_4" translatable="false">4</string>
-    <string name="_5" translatable="false">5</string>
-    <string name="_6" translatable="false">6</string>
-    <string name="_7" translatable="false">7</string>
-    <string name="_8" translatable="false">8</string>
     <string name="commit">커밋</string>
     <string name="app_drawer_tips">팁: 아래로 스와이프 하면 무시할 수 있고, 키보드를 숨기려면 스크롤 하세요.</string>
     <string name="okay">네</string>
@@ -65,9 +56,6 @@
     <string name="lang_system">시스템</string>
 
     <string name="app_text_size">텍스트 크기</string>
-    <string name="text_size_huge">크게</string>
-    <string name="text_size_normal">기본</string>
-    <string name="text_size_small">작게</string>
 
     <string name="hidden_apps">숨겨진 앱</string>
 

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -25,15 +25,6 @@
     <string name="swipe_right_app">Deslize para a direita app</string>
     <string name="clock_click_app">Aplicativo de relógio</string>
     <string name="date_click_app">Aplicativo de calendário</string>
-    <string name="_0" translatable="false">0</string>
-    <string name="_1" translatable="false">1</string>
-    <string name="_2" translatable="false">2</string>
-    <string name="_3" translatable="false">3</string>
-    <string name="_4" translatable="false">4</string>
-    <string name="_5" translatable="false">5</string>
-    <string name="_6" translatable="false">6</string>
-    <string name="_7" translatable="false">7</string>
-    <string name="_8" translatable="false">8</string>
     <string name="commit">Commit</string>
     <string name="app_drawer_tips">Dica: Deslize para baixo para dispensar. Scroll para ocultar o teclado.</string>
     <string name="okay">Okay</string>
@@ -62,20 +53,8 @@
     <string name="close">Fechar</string>
     <string name="app_language">Idioma da interface</string>
     <string name="lang_system">Sistema</string>
-    <string name="lang_en" translatable="false">English</string>
-    <string name="lang_de" translatable="false">Deutsch</string>
-    <string name="lang_es" translatable="false">Español</string>
-    <string name="lang_fr" translatable="false">Français</string>
-    <string name="lang_it" translatable="false">Italiano</string>
-    <string name="lang_pt" translatable="false">Português (Portugal)</string>
-    <string name="lang_se" translatable="false">Svenska</string>
-    <string name="lang_tr" translatable="false">Türkçe</string>
-    <string name="lang_gr" translatable="false">Ελληνικά</string>
 
     <string name="app_text_size">Tamanho de texto</string>
-    <string name="text_size_huge">Grande</string>
-    <string name="text_size_normal">Normal</string>
-    <string name="text_size_small">Pequeno</string>
 
     <string name="hidden_apps">Aplicações escondidas</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -25,15 +25,7 @@
     <string name="swipe_right_app">Свайпом вправо открыть</string>
     <string name="clock_click_app">Тапом часов открыть</string>
     <string name="date_click_app">Тапом даты открыть</string>
-    <string name="_0" translatable="false">0</string>
-    <string name="_1" translatable="false">1</string>
-    <string name="_2" translatable="false">2</string>
-    <string name="_3" translatable="false">3</string>
-    <string name="_4" translatable="false">4</string>
-    <string name="_5" translatable="false">5</string>
-    <string name="_6" translatable="false">6</string>
-    <string name="_7" translatable="false">7</string>
-    <string name="_8" translatable="false">8</string>
+
     <string name="commit">Применить</string>
     <string name="app_drawer_tips">Совет: Свайпните вниз, чтобы закрыть. Прокрутите, чтобы скрыть клавиатуру.</string>
     <string name="okay">Хорошо</string>
@@ -65,9 +57,6 @@
     <string name="lang_system">Системный</string>
 
     <string name="app_text_size">Размер текста</string>
-    <string name="text_size_huge">Huge</string>
-    <string name="text_size_normal">Normal</string>
-    <string name="text_size_small">Small</string>
 
     <string name="hidden_apps">Скрытые приложения</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -25,7 +25,6 @@
     <string name="swipe_right_app">Свайпом вправо открыть</string>
     <string name="clock_click_app">Тапом часов открыть</string>
     <string name="date_click_app">Тапом даты открыть</string>
-
     <string name="commit">Применить</string>
     <string name="app_drawer_tips">Совет: Свайпните вниз, чтобы закрыть. Прокрутите, чтобы скрыть клавиатуру.</string>
     <string name="okay">Хорошо</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -44,4 +44,6 @@
     <string name="open">Öppna länk</string>
     <string name="copy">Kopiera</string>
     <string name="close">Stäng</string>
+
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,9 +65,6 @@
     <string name="lang_system">System</string>
 
     <string name="app_text_size">Text Size</string>
-    <string name="text_size_huge">Huge</string>
-    <string name="text_size_normal">Normal</string>
-    <string name="text_size_small">Small</string>
 
     <string name="hidden_apps">Hidden apps</string>
 


### PR DESCRIPTION
Removed unnecessary strings from language files, like:

**Untranslatable strings:**
* `<string name="_0" translatable="false"></string>`
* `string name="lang_en" translatable="false"></string>`

**Unused strings:**
* `<string name="text_size_huge"></string>`
