### PR TITLE
Fixed typo that was preventing ClickDateApp change

### DIFF
--- a/app/src/main/java/app/olaunchercf/ui/HomeFragment.kt
+++ b/app/src/main/java/app/olaunchercf/ui/HomeFragment.kt
@@ -297,7 +297,7 @@ class HomeFragment : Fragment(), View.OnClickListener, View.OnLongClickListener 
     }
 
     private fun openClickDateApp() {
-        if (prefs.appPackageClickClock.isNotEmpty())
+        if (prefs.appPackageClickDate.isNotEmpty())
             launchApp(
                 prefs.appNameClickDate,
                 prefs.appPackageClickDate,


### PR DESCRIPTION
`openClickDateApp` was checking if `prefs.appPackageClickClock` is not empty instead of `prefs.appPackageClickDate`, which prevented date app change if clock app is not changed already. 

I think this was just a typo and this change should not break anything. 