### PR TITLE
add (little) more automation

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,13 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 20
+# Label requiring a response
+responseRequiredLabel: waiting for response
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-no-response - https://github.com/probot/no-response
 
 # Number of days of inactivity before an Issue is closed for lack of response
-daysUntilClose: 20
+daysUntilClose: 60
 # Label requiring a response
 responseRequiredLabel: waiting for response
 # Comment to post when closing an Issue for lack of response. Set to `false` to disable

--- a/.github/workflows/validate-gradle-wrapper.yaml
+++ b/.github/workflows/validate-gradle-wrapper.yaml
@@ -1,0 +1,11 @@
+name: Validate Gradle Wrapper
+
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
Hi @jooooscha, little PR to add:

A bot that will close an issue when:
1. A contributor assigns the label "waiting for response" _(this can be modified)_
2. A delay (currently set to 20 days) has elapsed. _(this can be edited, or deleted)_
_(these two conditions must be met, in this order)_

This requires free activation from: https://github.com/apps/no-response

Added gradle-wrapper.jar file verification

If this does not suit you, or it is useless, close the PR.

Thank you