### PR TITLE
Correct language names

### DIFF
--- a/app/src/main/java/app/olaunchercf/data/Constants.kt
+++ b/app/src/main/java/app/olaunchercf/data/Constants.kt
@@ -58,7 +58,7 @@ object Constants {
         override fun string(): String {
             return when(this) {
                 System -> stringResource(R.string.lang_system)
-                Chinese -> "中国人"
+                Chinese -> "中文"
                 Croatian -> "Hrvatski"
                 English -> "English"
                 Estonian -> "Eesti keel"
@@ -67,7 +67,7 @@ object Constants {
                 Greek -> "Ελληνική"
                 Indonesian -> "Bahasa Indonesia"
                 Italian -> "Italiano"
-                Korean -> "조선말"
+                Korean -> "한국어"
                 Persian -> "فارسی"
                 Portuguese -> "Português"
                 Russian -> "Русский"


### PR DESCRIPTION
中国人 = "Chinese people"
中文 = "Chinese language"

Additionally 조선말 is the North Korean word for the Korean language, and is not generally used in South Korea